### PR TITLE
Cms 17 create cms connector endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <groupId>com.appdirect</groupId>
   <artifactId>service-integration-sdk</artifactId>
   <packaging>jar</packaging>
-  <version>1.41-SNAPSHOT</version>
+  <version>1.44-SNAPSHOT</version>
   <name>SDK for service integration</name>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <groupId>com.appdirect</groupId>
   <artifactId>service-integration-sdk</artifactId>
   <packaging>jar</packaging>
-  <version>1.44-SNAPSHOT</version>
+  <version>1.46-SNAPSHOT</version>
   <name>SDK for service integration</name>
 
   <properties>

--- a/src/main/java/com/appdirect/sdk/ConnectorSdkConfiguration.java
+++ b/src/main/java/com/appdirect/sdk/ConnectorSdkConfiguration.java
@@ -16,6 +16,8 @@ package com.appdirect.sdk;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import com.appdirect.sdk.appmarket.dataconnections.DataConnectionsCommunicationConfiguration;
+import com.appdirect.sdk.appmarket.dataconnections.DefaultDataConnectionsHandlers;
 import com.appdirect.sdk.appmarket.events.AppmarketCommunicationConfiguration;
 import com.appdirect.sdk.appmarket.events.DefaultEventHandlersForOptionalEvents;
 import com.appdirect.sdk.appmarket.events.EventHandlingConfiguration;
@@ -36,6 +38,8 @@ import com.appdirect.sdk.web.oauth.SecurityConfiguration;
 		SecurityConfiguration.class,
 		DefaultEventHandlersForOptionalEvents.class,
 		EventHandlingConfiguration.class,
+		DefaultDataConnectionsHandlers.class,
+		DataConnectionsCommunicationConfiguration.class,
 		AppmarketCommunicationConfiguration.class,
 		DefaultMigrationHandlers.class,
 		DefaultValidationHandlers.class,

--- a/src/main/java/com/appdirect/sdk/appmarket/AppmarketDataConnectionAuthorizationHandler.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/AppmarketDataConnectionAuthorizationHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket;
+
+import com.appdirect.sdk.appmarket.dataconnections.DataConnectionsAPIResult;
+import com.appdirect.sdk.appmarket.dataconnections.DataConnectionsHandlingContext;
+import com.appdirect.sdk.appmarket.events.AppmarketEventClient;
+
+/**
+ * This is the interface you need to implement to support handling appmarket data connections
+ * authorizations in your connector.
+ *
+ */
+@FunctionalInterface
+public interface AppmarketDataConnectionAuthorizationHandler {
+
+	/**
+	 *  TODO: is async needed for dataConnections?
+	 * For async events (everything but <code>SUBSCRIPTION_NOTICE</code> events),
+	 * returning a <code>null</code> result will not resolve the event on the appmarket's side.
+	 * You will have to manually resolve the event using {@link AppmarketEventClient#resolve} at a later point in time.
+	 * @param context the context
+	 * @return the result that will be sent to the appmarket to resolve the event, or <code>null</code> if you the event is to be resolved later.
+	 */
+	DataConnectionsAPIResult handleAuthorization(DataConnectionsHandlingContext context);
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/AppmarketDataConnectionWebhooksHandler.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/AppmarketDataConnectionWebhooksHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket;
+
+import com.appdirect.sdk.appmarket.dataconnections.DataConnectionsAPIResult;
+import com.appdirect.sdk.appmarket.dataconnections.DataConnectionsHandlingContext;
+import com.appdirect.sdk.appmarket.events.AppmarketEventClient;
+
+/**
+ * This is the interface you need to implement to support handling appmarket data connection
+ * webhooks in your connector.
+ *
+ */
+@FunctionalInterface
+public interface AppmarketDataConnectionWebhooksHandler {
+
+	/**
+	 *  TODO: is async needed for dataConnections?
+	 * For async events (everything but <code>SUBSCRIPTION_NOTICE</code> events),
+	 * returning a <code>null</code> result will not resolve the event on the appmarket's side.
+	 * You will have to manually resolve the event using {@link AppmarketEventClient#resolve} at a later point in time.
+	 * @param context the context
+	 * @return the result that will be sent to the appmarket to resolve the event, or <code>null</code> if you the event is to be resolved later.
+	 */
+	DataConnectionsAPIResult handleWebhooks(DataConnectionsHandlingContext context);
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/AuthorizationHandleWrapper.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/AuthorizationHandleWrapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.dataconnections;
+
+import com.appdirect.sdk.appmarket.AppmarketDataConnectionAuthorizationHandler;
+
+/**
+ * SDK internal - Convenience class that wraps data connection handler
+ *
+ */
+class AuthorizationHandleWrapper implements SDKDataConnectionsAuthorizationHandler {
+
+	private final AppmarketDataConnectionAuthorizationHandler dataConnectionHandler;
+
+	AuthorizationHandleWrapper(AppmarketDataConnectionAuthorizationHandler dataConnectionHandler) {
+		this.dataConnectionHandler = dataConnectionHandler;
+	}
+
+	@Override
+	public DataConnectionsAPIResult handleAuthorization(DataConnectionsHandlingContext context) {
+		return dataConnectionHandler.handleAuthorization(context);
+	}
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionType.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionType.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.dataconnections;
+
+enum DataConnectionType {
+	AUTHORIZATION,
+	WEBHOOK,
+	UNKNOWN
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAPIResult.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAPIResult.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.dataconnections;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import com.appdirect.sdk.appmarket.events.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The payload that is sent back to the AppMarket in response to a data connection event.
+ */
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class  DataConnectionsAPIResult {
+	private boolean success;
+	private ErrorCode errorCode;
+	private String message;
+	private String accountIdentifier;
+	private String userIdentifier;
+	@JsonIgnore
+	private int statusCodeReturnedToAppmarket;
+
+	public DataConnectionsAPIResult(ErrorCode errorCode, String message) {
+		this(false, message);
+		this.errorCode = errorCode;
+	}
+
+	@JsonCreator
+	public DataConnectionsAPIResult(@JsonProperty("success") boolean success,
+																	@JsonProperty("message") String message) {
+		this.success = success;
+		this.message = message;
+	}
+
+	public static DataConnectionsAPIResult success(String message) {
+		DataConnectionsAPIResult result = new DataConnectionsAPIResult(true, message);
+		result.setStatusCodeReturnedToAppmarket(200);
+		return result;
+	}
+
+	public static DataConnectionsAPIResult asyncEventResult(String message) {
+		DataConnectionsAPIResult result = new DataConnectionsAPIResult(true, message);
+		result.setStatusCodeReturnedToAppmarket(202);
+		return result;
+	}
+
+	/**
+	 * Creates a failed result with the given error code and message.
+	 * Note: HTTP OK (200) will be returned to the appmarket; all responses
+	 * going to the appmarket need to have a 200 status, whether they are successful or not.
+	 *
+	 * @param errorCode the code of the error
+	 * @param message   human-readable error message that explains the issue.
+	 * @return the failed result object
+	 */
+	public static DataConnectionsAPIResult failure(ErrorCode errorCode, String message) {
+		DataConnectionsAPIResult result = new DataConnectionsAPIResult(errorCode, message);
+		result.setStatusCodeReturnedToAppmarket(200);
+		return result;
+	}
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAPIResult.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAPIResult.java
@@ -40,6 +40,8 @@ public class  DataConnectionsAPIResult {
 	private String userIdentifier;
 	@JsonIgnore
 	private int statusCodeReturnedToAppmarket;
+	// allows the overriding of authorization response page
+	private DataConnectionsAuthorizationResponse authorizationResponse;
 
 	public DataConnectionsAPIResult(ErrorCode errorCode, String message) {
 		this(false, message);
@@ -55,6 +57,12 @@ public class  DataConnectionsAPIResult {
 	public static DataConnectionsAPIResult success(String message) {
 		DataConnectionsAPIResult result = new DataConnectionsAPIResult(true, message);
 		result.setStatusCodeReturnedToAppmarket(200);
+		return result;
+	}
+
+	public static DataConnectionsAPIResult success(String message, DataConnectionsAuthorizationResponse authorizationResponse) {
+		DataConnectionsAPIResult result = success(message);
+		result.setAuthorizationResponse(authorizationResponse);
 		return result;
 	}
 
@@ -76,6 +84,12 @@ public class  DataConnectionsAPIResult {
 	public static DataConnectionsAPIResult failure(ErrorCode errorCode, String message) {
 		DataConnectionsAPIResult result = new DataConnectionsAPIResult(errorCode, message);
 		result.setStatusCodeReturnedToAppmarket(200);
+		return result;
+	}
+
+	public static DataConnectionsAPIResult failure(ErrorCode errorCode, String message, DataConnectionsAuthorizationResponse authorizationResponse) {
+		DataConnectionsAPIResult result = failure(errorCode, message);
+		result.setAuthorizationResponse(authorizationResponse);
 		return result;
 	}
 }

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAPIResult.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAPIResult.java
@@ -47,8 +47,7 @@ public class  DataConnectionsAPIResult {
 	}
 
 	@JsonCreator
-	public DataConnectionsAPIResult(@JsonProperty("success") boolean success,
-																	@JsonProperty("message") String message) {
+	public DataConnectionsAPIResult(@JsonProperty("success") boolean success, @JsonProperty("message") String message) {
 		this.success = success;
 		this.message = message;
 	}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAuthorizationDispatcher.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAuthorizationDispatcher.java
@@ -25,9 +25,10 @@ public class DataConnectionsAuthorizationDispatcher {
 	private final SDKDataConnectionsAuthorizationHandler authorizationHandler;
 	private final SDKDataConnectionsAuthorizationHandler unknownHandler;
 
-	DataConnectionsAuthorizationDispatcher(//AsyncEventHandler asyncHandler,
-																				 SDKDataConnectionsAuthorizationHandler authorizationHandler,
-																				 SDKDataConnectionsAuthorizationHandler unknownHandler) {
+	DataConnectionsAuthorizationDispatcher(
+			//AsyncEventHandler asyncHandler,
+			SDKDataConnectionsAuthorizationHandler authorizationHandler,
+			SDKDataConnectionsAuthorizationHandler unknownHandler) {
 		//this.asyncHandler = asyncHandler;
 		this.authorizationHandler = authorizationHandler;
 		this.unknownHandler = unknownHandler;
@@ -36,26 +37,26 @@ public class DataConnectionsAuthorizationDispatcher {
 	/**
 	 * Resolves the appropriate SDK-internal handler that corresponds to the incoming data and
 	 * forwards the data to it
+	 *
 	 * @param context
+	 *
 	 * @return
 	 */
 	DataConnectionsAPIResult dispatchAndHandle(DataConnectionsHandlingContext context) {
-
 		//SDKDataConnectionsAuthorizationHandler handler = getHandlerFor(context);
 //		if (events.eventShouldBeHandledAsync(rawEvent)) {
 //			return asyncHandler.handle(eventHandler, rawEvent, eventContext);
 //		} else {
 //			return eventHandler.handle(rawEvent, eventContext);
 //		}
-		// no support for asyn, so just handle it one way
+		// no support for async, so just handle it one way
 		return getHandlerFor(context).handleAuthorization(context);
-
 	}
 
 	private SDKDataConnectionsAuthorizationHandler getHandlerFor(final DataConnectionsHandlingContext context) {
 
 		DataConnectionType currentType = DataConnectionType.AUTHORIZATION;
-		// TODO: better way of idenfiying non-authorization
+		// TODO: better way of idenfiying non-authorization requests?
 		if (!context.getRequest().getParameterMap().containsKey("source"))
 		{
 			currentType = DataConnectionType.UNKNOWN;

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAuthorizationDispatcher.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAuthorizationDispatcher.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.dataconnections;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Dispatches incoming data to the appropriate handler.
+ */
+public class DataConnectionsAuthorizationDispatcher {
+	//private final AsyncEventHandler asyncHandler;
+	private final SDKDataConnectionsAuthorizationHandler authorizationHandler;
+	private final SDKDataConnectionsAuthorizationHandler unknownHandler;
+
+	DataConnectionsAuthorizationDispatcher(//AsyncEventHandler asyncHandler,
+																				 SDKDataConnectionsAuthorizationHandler authorizationHandler,
+																				 SDKDataConnectionsAuthorizationHandler unknownHandler) {
+		//this.asyncHandler = asyncHandler;
+		this.authorizationHandler = authorizationHandler;
+		this.unknownHandler = unknownHandler;
+	}
+
+	/**
+	 * Resolves the appropriate SDK-internal handler that corresponds to the incoming data and
+	 * forwards the data to it
+	 * @param context
+	 * @return
+	 */
+	DataConnectionsAPIResult dispatchAndHandle(DataConnectionsHandlingContext context) {
+
+		//SDKDataConnectionsAuthorizationHandler handler = getHandlerFor(context);
+//		if (events.eventShouldBeHandledAsync(rawEvent)) {
+//			return asyncHandler.handle(eventHandler, rawEvent, eventContext);
+//		} else {
+//			return eventHandler.handle(rawEvent, eventContext);
+//		}
+		// no support for asyn, so just handle it one way
+		return getHandlerFor(context).handleAuthorization(context);
+
+	}
+
+	private SDKDataConnectionsAuthorizationHandler getHandlerFor(final DataConnectionsHandlingContext context) {
+
+		DataConnectionType currentType = DataConnectionType.AUTHORIZATION;
+		// TODO: better way of idenfiying non-authorization
+		if (!context.getRequest().getParameterMap().containsKey("source"))
+		{
+			currentType = DataConnectionType.UNKNOWN;
+		}
+
+		Map<DataConnectionType, Supplier<SDKDataConnectionsAuthorizationHandler>> contextToHandlers = new EnumMap<>(DataConnectionType.class);
+
+		contextToHandlers.put(DataConnectionType.AUTHORIZATION, () -> authorizationHandler);
+		contextToHandlers.put(DataConnectionType.UNKNOWN, () -> unknownHandler);
+
+		return contextToHandlers.getOrDefault(currentType, () -> unknownHandler).get();
+	}
+
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAuthorizationInfo.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAuthorizationInfo.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.dataconnections;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ *
+ * Representation of the the params and values required below are per Dave's spec outlined in the
+ * "User Authorization Configurator API Endpoint" section of this page:
+ * https://appdirect.jira.com/wiki/spaces/EN/pages/220995076/Outbound+Connect+Flow
+ *
+ * SDK internal, a user of the SDK should never interact with those directly.
+ */
+@Getter
+@ToString
+@AllArgsConstructor
+@Builder
+public class DataConnectionsAuthorizationInfo {
+
+	private String appId;
+	private String userId;
+	private String companyId;
+	private String baseUrl;
+	private String source; // Either "visualization" (for AppInsights) or "content" (for AppWise)
+	// These names match the API URL paths the ISVs need to use for the First Parties.
+
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAuthorizationInfo.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAuthorizationInfo.java
@@ -20,12 +20,10 @@ import lombok.Setter;
 import lombok.ToString;
 
 /**
- *
  * Representation of the the params and values required below are per Dave's spec outlined in the
  * "User Authorization Configurator API Endpoint" section of this page:
  * https://appdirect.jira.com/wiki/spaces/EN/pages/220995076/Outbound+Connect+Flow
  *
- * SDK internal, a user of the SDK should never interact with those directly.
  */
 @Getter
 @ToString

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAuthorizationResponse.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAuthorizationResponse.java
@@ -1,0 +1,61 @@
+package com.appdirect.sdk.appmarket.dataconnections;
+
+import com.appdirect.sdk.appmarket.events.ErrorCode;
+
+/**
+ * This interface defines two methods (with default implementations) that define the response page
+ * to authoziation requests for data connections. I.e. when a user clicks 'Connect' to a CMS
+ * (AppInsights or AppWise) connector, the string returned from these methods are used as the
+ * response page to a successful or failed authorization.
+ */
+public interface DataConnectionsAuthorizationResponse {
+
+	/**
+	 * This method returns the default success html page for Authorization requests for data connections.
+	 * It can be overridden by developers implementing the data connection authorization handler who
+	 * want to control the result page.
+	 * @return  the default success html page for Authorization requests for data connections
+	 */
+	default String success() {
+		String result = "<html><head>\n" +
+				"    <title>Authorization Success</title>\n" +
+				"    <style>\n" +
+				"        body { padding: 1em; text-align: center; }\n" +
+				"    </style>\n" +
+				"</head>\n" +
+				"<body>\n" +
+				"<p><b>Authorization Success</b></p>\n" +
+				"\n" +
+				"<p>Authorization was successful. Please close this window.</p>\n" +
+				"\n" +
+				"</body></html>";
+		return result;
+	}
+
+	/**
+	 * This method returns the default failure html page for Authorization requests for data connections.
+	 * It incorporates the passed in errorCode and message.
+	 * It can be overridden by developers implementing the data connection authorization handler who
+	 * want to control the result page.
+	 * @param errorCode failure errorCode
+	 * @param message failure message
+	 * @return the default failure html page for Authorization requests for data connections
+	 */
+	default String failure (ErrorCode errorCode, String message) {
+		String result = "<html><head>\n" +
+				"    <title>Authorization Failure</title>\n" +
+				"    <style>\n" +
+				"        body { padding: 1em; text-align: center; }\n" +
+				"    </style>\n" +
+				"</head>\n" +
+				"<body>\n" +
+				"<p><b>Authorization Failue</b></p>\n" +
+				"\n" +
+				"<p>Authorization was unsuccessful. Please close this window and try again.</p>\n" +
+				"\n" +
+				"<p>Message: " + message + ". Code: " + errorCode + ".</p>\n" +
+				"\n" +
+				"</body></html>";
+		return result;
+	}
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAuthorizationResponseDefaultImpl.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAuthorizationResponseDefaultImpl.java
@@ -1,0 +1,8 @@
+package com.appdirect.sdk.appmarket.dataconnections;
+
+/**
+ * This is the default implementation of DataConnectionsAuthorizationResponse. It uses the default
+ * implemenations in the interface.
+ */
+public class DataConnectionsAuthorizationResponseDefaultImpl implements DataConnectionsAuthorizationResponse {
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAuthorizationService.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsAuthorizationService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.dataconnections;
+
+import static com.appdirect.sdk.appmarket.events.ErrorCode.UNKNOWN_ERROR;
+import static java.lang.String.format;
+
+import lombok.extern.slf4j.Slf4j;
+
+import com.appdirect.sdk.exception.DeveloperServiceException;
+
+@Slf4j
+public class DataConnectionsAuthorizationService {
+
+	private final DataConnectionsAuthorizationDispatcher dispatcher;
+
+	public DataConnectionsAuthorizationService(DataConnectionsAuthorizationDispatcher dispatcher) {
+		this.dispatcher = dispatcher;
+	}
+
+	/**
+	 * Process authorization connections data from the AppMarket or Application
+	 *
+	 * @param context
+	 *
+	 * @return
+	 */
+	DataConnectionsAPIResult processData(DataConnectionsHandlingContext context) {
+		log.info("processing connections data for contxt={}", context);
+		try {
+			return dispatcher.dispatchAndHandle(context);
+		} catch (DeveloperServiceException e) {
+			log.error("Service returned an error for context={}, result={}", context, e.getResult());
+			throw e;
+		} catch (RuntimeException e) {
+			log.error("Exception while attempting to process connections data. context={}", context, e);
+			throw new DeveloperServiceException(UNKNOWN_ERROR, format("Failed to process connections data. context=%s | exception=%s", context, e.getMessage()));
+		}
+	}
+
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsCommunicationConfiguration.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsCommunicationConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.dataconnections;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+//@SpringBootApplication(scanBasePackages = { "com.appdirect.sdk.appmarket.dataconnections", "com.appdirect.sdk.appmarket.events", "com.appdirect.sdk.appmarket"})
+@SpringBootApplication(scanBasePackages = { "com.appdirect.sdk.appmarket.dataconnections"})
+@Configuration
+public class DataConnectionsCommunicationConfiguration {
+
+	@Bean
+	public DataConnectionsAuthorizationService dataConnectionsService(DataConnectionsAuthorizationDispatcher dispatcher) {
+		return new DataConnectionsAuthorizationService(dispatcher);
+	}
+
+	@Bean
+	public DataConnectionsWebhooksService dataConnectionsWebhooksService(DataConnectionsWebhooksDispatcher dispatcher) {
+		return new DataConnectionsWebhooksService(dispatcher);
+	}
+
+	@Bean
+	public DataConnectionsController dataConnectionsController(DataConnectionsAuthorizationService dataConnectionsAuthorizationService, DataConnectionsWebhooksService dataConnectionsWebhooksService) {
+		return new DataConnectionsController(dataConnectionsAuthorizationService, dataConnectionsWebhooksService);
+	}
+
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsController.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsController.java
@@ -37,22 +37,24 @@ public class DataConnectionsController {
 	private final DataConnectionsWebhooksService dataConnectionsWebhooksService;
 	private String payload;
 
-	public DataConnectionsController(DataConnectionsAuthorizationService dataConnectionsAuthorizationService,
-																	 DataConnectionsWebhooksService dataConnectionsWebhooksService) {
+	public DataConnectionsController(
+			DataConnectionsAuthorizationService dataConnectionsAuthorizationService,
+			DataConnectionsWebhooksService dataConnectionsWebhooksService) {
 		this.dataConnectionsAuthorizationService = dataConnectionsAuthorizationService;
 		this.dataConnectionsWebhooksService = dataConnectionsWebhooksService;
 	}
 
 	/**
 	 * Defines the connector endpoint to which AppDirect Integrations (AI / AW) connect authorization should be sent.
-	 *
 	 * @param request the http request
 	 * @param source  the source from which the connect authorization request is coming from (i.e. AppWise or AppInsights)
-	 *
 	 * @return the HTTP response to return to the AppMarket.
 	 */
 	@RequestMapping(method = GET, value = "/authorization", produces = APPLICATION_JSON_VALUE)
-	public ResponseEntity<DataConnectionsAPIResult> authorization(HttpServletRequest request, HttpServletResponse response, @RequestParam("source") String source) {
+	public ResponseEntity<DataConnectionsAPIResult> authorization(
+			HttpServletRequest request,
+			HttpServletResponse response,
+			@RequestParam("source") String source) {
 		// TODO: consider adding all required parameters i.e. appId, userId, companyId, baseUrl, along with source
 		log.info("authorization: source={} ", source);
 
@@ -64,14 +66,16 @@ public class DataConnectionsController {
 
 	/**
 	 * Defines the connector endpoint to which AppDirect Integrations webhook (AI / AW) events should be sent.
-	 *
 	 * @param request  the http request
 	 * @param response the http response
 	 *
 	 * @return the HTTP response to return to the AppMarket.
 	 */
 	@RequestMapping(method = POST, value = "/webhooks", produces = APPLICATION_JSON_VALUE)
-	public ResponseEntity<DataConnectionsAPIResult> webhooks(HttpServletRequest request, HttpServletResponse response, @RequestBody String payload) {
+	public ResponseEntity<DataConnectionsAPIResult> webhooks(
+			HttpServletRequest request,
+			HttpServletResponse response,
+			@RequestBody String payload) {
 		this.payload = payload;
 
 		log.info("webhook: payload={} ", payload);

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsController.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsController.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.dataconnections;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+public class DataConnectionsController {
+
+	private final DataConnectionsAuthorizationService dataConnectionsAuthorizationService;
+	private final DataConnectionsWebhooksService dataConnectionsWebhooksService;
+	private String payload;
+
+	public DataConnectionsController(DataConnectionsAuthorizationService dataConnectionsAuthorizationService,
+																	 DataConnectionsWebhooksService dataConnectionsWebhooksService) {
+		this.dataConnectionsAuthorizationService = dataConnectionsAuthorizationService;
+		this.dataConnectionsWebhooksService = dataConnectionsWebhooksService;
+	}
+
+	/**
+	 * Defines the connector endpoint to which AppDirect Integrations (AI / AW) connect authorization should be sent.
+	 *
+	 * @param request the http request
+	 * @param source  the source from which the connect authorization request is coming from (i.e. AppWise or AppInsights)
+	 *
+	 * @return the HTTP response to return to the AppMarket.
+	 */
+	@RequestMapping(method = GET, value = "/authorization", produces = APPLICATION_JSON_VALUE)
+	public ResponseEntity<DataConnectionsAPIResult> authorization(HttpServletRequest request, HttpServletResponse response, @RequestParam("source") String source) {
+		// TODO: consider adding all required parameters i.e. appId, userId, companyId, baseUrl, along with source
+		log.info("authorization: source={} ", source);
+
+		DataConnectionsAPIResult result = dataConnectionsAuthorizationService.processData(executionContext(request, response));
+
+		log.info("authorization: apiResult={}", result);
+		return new ResponseEntity<>(result, httpStatusOf(result));
+	}
+
+	/**
+	 * Defines the connector endpoint to which AppDirect Integrations webhook (AI / AW) events should be sent.
+	 *
+	 * @param request  the http request
+	 * @param response the http response
+	 *
+	 * @return the HTTP response to return to the AppMarket.
+	 */
+	@RequestMapping(method = POST, value = "/webhooks", produces = APPLICATION_JSON_VALUE)
+	public ResponseEntity<DataConnectionsAPIResult> webhooks(HttpServletRequest request, HttpServletResponse response, @RequestBody String payload) {
+		this.payload = payload;
+
+		log.info("webhook: payload={} ", payload);
+
+		DataConnectionsAPIResult result = dataConnectionsWebhooksService.processData(executionContext(request, response, payload));
+
+		log.info("webbhook: result={}", result);
+		return new ResponseEntity<>(result, httpStatusOf(result));
+	}
+
+	private DataConnectionsHandlingContext executionContext(HttpServletRequest request, HttpServletResponse response) {
+		return new DataConnectionsHandlingContext(request, response);
+	}
+
+	private DataConnectionsHandlingContext executionContext(HttpServletRequest request, HttpServletResponse response, String payload) {
+		return new DataConnectionsHandlingContext(request, response, payload);
+	}
+
+	private HttpStatus httpStatusOf(DataConnectionsAPIResult result) {
+		return HttpStatus.valueOf(result.getStatusCodeReturnedToAppmarket());
+	}
+
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsHandlingConfiguration.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsHandlingConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.dataconnections;
+
+import static com.appdirect.sdk.appmarket.events.ErrorCode.CONFIGURATION_ERROR;
+import static java.lang.String.format;
+import static java.util.concurrent.Executors.newWorkStealingPool;
+
+import java.util.concurrent.ExecutorService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.appdirect.sdk.appmarket.AppmarketDataConnectionAuthorizationHandler;
+import com.appdirect.sdk.appmarket.AppmarketDataConnectionWebhooksHandler;
+import com.appdirect.sdk.executor.MdcExecutor;
+
+@Configuration
+@RequiredArgsConstructor
+public class DataConnectionsHandlingConfiguration {
+
+	private final AppmarketDataConnectionAuthorizationHandler authorizationHandler;
+	private final AppmarketDataConnectionWebhooksHandler webhooksHandler;
+
+	@Bean
+	SDKDataConnectionsAuthorizationHandler unknownHandler() {
+		return (context) -> new DataConnectionsAPIResult(CONFIGURATION_ERROR, format("Unsupported data connections authorization context %s", context));
+	}
+
+	@Bean(destroyMethod = "shutdown")
+	public ExecutorService defaultExecutorService() {
+		return new MdcExecutor(newWorkStealingPool());
+	}
+
+	@Bean
+	public DataConnectionsAuthorizationDispatcher dataConnectionDispatcher() {
+		return new DataConnectionsAuthorizationDispatcher(
+				new AuthorizationHandleWrapper(authorizationHandler),
+				unknownHandler());
+	}
+
+	@Bean
+	SDKDataConnectionsWebhooksHandler unknownWebhooksHandler() {
+		return (context) -> new DataConnectionsAPIResult(CONFIGURATION_ERROR, format("Unsupported data connections webhooks context %s", context));
+	}
+
+	@Bean
+	public DataConnectionsWebhooksDispatcher dataConnectionWebhooksDispatcher() {
+		return new DataConnectionsWebhooksDispatcher(
+				new WebhooksHandleWrapper(webhooksHandler),
+				unknownWebhooksHandler());
+	}
+
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsHandlingContext.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsHandlingContext.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.dataconnections;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode
+public class DataConnectionsHandlingContext {
+
+	private final HttpServletRequest request;
+	private final HttpServletResponse response;
+	private final String payload;
+
+	DataConnectionsHandlingContext(HttpServletRequest request, HttpServletResponse response) {
+		this.request = request;
+		this.response = response;
+		this.payload = null;
+	}
+
+	DataConnectionsHandlingContext(HttpServletRequest request, HttpServletResponse response, String payload) {
+		this.request = request;
+		this.response = response;
+		this.payload = payload;
+	}
+
+	public HttpServletRequest getRequest() {
+		return request;
+	}
+
+	public HttpServletResponse getResponse() {
+		return response;
+	}
+
+	public String getPayload() { return payload; }
+
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsWebhooksDispatcher.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsWebhooksDispatcher.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.dataconnections;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+/**
+ * Dispatches incoming data to the appropriate handler.
+ */
+public class DataConnectionsWebhooksDispatcher {
+	private final SDKDataConnectionsWebhooksHandler webhooksHandler;
+	private final SDKDataConnectionsWebhooksHandler unknownHandler;
+
+	DataConnectionsWebhooksDispatcher(//AsyncEventHandler asyncHandler
+																		SDKDataConnectionsWebhooksHandler webhooksHandler,
+																		SDKDataConnectionsWebhooksHandler unknownHandler) {
+		//this.asyncHandler = asyncHandler;
+		this.webhooksHandler = webhooksHandler;
+		this.unknownHandler = unknownHandler;
+	}
+
+	/**
+	 * Resolves the appropriate SDK-internal handler that corresponds to the incoming data and
+	 * forwards the data to it
+	 * @param context
+	 * @return
+	 */
+	DataConnectionsAPIResult dispatchAndHandle(DataConnectionsHandlingContext context) {
+
+		//SDKDataConnectionsAuthorizationHandler handler = getHandlerFor(context);
+
+//		if (events.eventShouldBeHandledAsync(rawEvent)) {
+//			return asyncHandler.handle(eventHandler, rawEvent, eventContext);
+//		} else {
+//			return eventHandler.handle(rawEvent, eventContext);
+//		}
+		// no support for asyn, so just handle it one way
+		return getHandlerFor(context).handleWebhooks(context);
+
+	}
+
+
+
+	private SDKDataConnectionsWebhooksHandler getHandlerFor(final DataConnectionsHandlingContext context) {
+
+		DataConnectionType currentType = DataConnectionType.WEBHOOK;
+		// TODO: better way of idenfiying webhook? webhooks are POST, authorize are GET
+		if (!context.getRequest().getMethod().equalsIgnoreCase("POST"))
+		{
+			currentType = DataConnectionType.UNKNOWN;
+		}
+
+
+		Map<DataConnectionType, Supplier<SDKDataConnectionsWebhooksHandler>> contextToHandlers = new EnumMap<>(DataConnectionType.class);
+		contextToHandlers.put(DataConnectionType.WEBHOOK, () -> webhooksHandler);
+		contextToHandlers.put(DataConnectionType.UNKNOWN, () -> unknownHandler);
+
+		return contextToHandlers.getOrDefault(currentType, () -> unknownHandler).get();
+	}
+
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsWebhooksDispatcher.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsWebhooksDispatcher.java
@@ -17,8 +17,6 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import org.springframework.beans.factory.annotation.Qualifier;
-
 /**
  * Dispatches incoming data to the appropriate handler.
  */
@@ -26,9 +24,10 @@ public class DataConnectionsWebhooksDispatcher {
 	private final SDKDataConnectionsWebhooksHandler webhooksHandler;
 	private final SDKDataConnectionsWebhooksHandler unknownHandler;
 
-	DataConnectionsWebhooksDispatcher(//AsyncEventHandler asyncHandler
-																		SDKDataConnectionsWebhooksHandler webhooksHandler,
-																		SDKDataConnectionsWebhooksHandler unknownHandler) {
+	DataConnectionsWebhooksDispatcher(
+			//AsyncEventHandler asyncHandler
+			SDKDataConnectionsWebhooksHandler webhooksHandler,
+			SDKDataConnectionsWebhooksHandler unknownHandler) {
 		//this.asyncHandler = asyncHandler;
 		this.webhooksHandler = webhooksHandler;
 		this.unknownHandler = unknownHandler;
@@ -37,7 +36,9 @@ public class DataConnectionsWebhooksDispatcher {
 	/**
 	 * Resolves the appropriate SDK-internal handler that corresponds to the incoming data and
 	 * forwards the data to it
+	 *
 	 * @param context
+	 *
 	 * @return
 	 */
 	DataConnectionsAPIResult dispatchAndHandle(DataConnectionsHandlingContext context) {
@@ -54,8 +55,6 @@ public class DataConnectionsWebhooksDispatcher {
 
 	}
 
-
-
 	private SDKDataConnectionsWebhooksHandler getHandlerFor(final DataConnectionsHandlingContext context) {
 
 		DataConnectionType currentType = DataConnectionType.WEBHOOK;
@@ -64,7 +63,6 @@ public class DataConnectionsWebhooksDispatcher {
 		{
 			currentType = DataConnectionType.UNKNOWN;
 		}
-
 
 		Map<DataConnectionType, Supplier<SDKDataConnectionsWebhooksHandler>> contextToHandlers = new EnumMap<>(DataConnectionType.class);
 		contextToHandlers.put(DataConnectionType.WEBHOOK, () -> webhooksHandler);

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsWebhooksService.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DataConnectionsWebhooksService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.dataconnections;
+
+import static com.appdirect.sdk.appmarket.events.ErrorCode.UNKNOWN_ERROR;
+import static java.lang.String.format;
+
+import lombok.extern.slf4j.Slf4j;
+
+import com.appdirect.sdk.exception.DeveloperServiceException;
+
+@Slf4j
+public class DataConnectionsWebhooksService {
+
+	private final DataConnectionsWebhooksDispatcher dispatcher;
+
+	public DataConnectionsWebhooksService(DataConnectionsWebhooksDispatcher dispatcher) {
+		this.dispatcher = dispatcher;
+	}
+
+	/**
+	 * Process webhook connections data from the AppMarket or Application
+	 * @param context
+	 * @return
+	 */
+	DataConnectionsAPIResult processData(DataConnectionsHandlingContext context) {
+		log.info("processing connections data for context={}", context);
+		try {
+			return dispatcher.dispatchAndHandle(context);
+		} catch (DeveloperServiceException e) {
+			log.error("Service returned an error for context={}, result={}", context, e.getResult());
+			throw e;
+		} catch (RuntimeException e) {
+			log.error("Exception while attempting to process connections data. context={}", context, e);
+			throw new DeveloperServiceException(UNKNOWN_ERROR, format("Failed to process connections data. context=%s | exception=%s", context, e.getMessage()));
+		}
+	}
+
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DefaultDataConnectionsHandlers.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DefaultDataConnectionsHandlers.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.dataconnections;
+
+import static com.appdirect.sdk.appmarket.dataconnections.DataConnectionsAPIResult.failure;
+import static com.appdirect.sdk.appmarket.events.ErrorCode.CONFIGURATION_ERROR;
+import static java.lang.String.format;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import com.appdirect.sdk.appmarket.AppmarketDataConnectionAuthorizationHandler;
+import com.appdirect.sdk.appmarket.AppmarketDataConnectionWebhooksHandler;
+
+/**
+ * Configuration class supplying data connector handlers for optional data connection events.
+ * Connector developers simply need to annotate handler beans they supply with {@link Primary}
+ * and Spring will pick them up instead of defaulting to the "dummy" ones.
+ */
+public class DefaultDataConnectionsHandlers {
+
+	@Bean
+	public AppmarketDataConnectionAuthorizationHandler defaultDataConnectionHandler() {
+		return (context) -> defaultErrorResponse("default");
+	}
+
+	@Bean
+	public AppmarketDataConnectionWebhooksHandler defaultDataConnectionWebhooksHandler() {
+		return (context) -> defaultErrorResponse("default");
+	}
+
+	private DataConnectionsAPIResult defaultErrorResponse(String dataConnectorName) {
+		return failure(CONFIGURATION_ERROR, format("Data connector with name (%s) is not supported by this connector.", new Object[]{dataConnectorName}));
+	}
+
+	private DataConnectionsAPIResult defaultErrorResponse() {
+		return failure(CONFIGURATION_ERROR, format("This data connector DEFAULT is not supported by this connector."));
+	}
+
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DefaultDataConnectionsHandlers.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/DefaultDataConnectionsHandlers.java
@@ -31,7 +31,7 @@ import com.appdirect.sdk.appmarket.AppmarketDataConnectionWebhooksHandler;
 public class DefaultDataConnectionsHandlers {
 
 	@Bean
-	public AppmarketDataConnectionAuthorizationHandler defaultDataConnectionHandler() {
+	public AppmarketDataConnectionAuthorizationHandler defaultDataConnectionAuthorizationHandler() {
 		return (context) -> defaultErrorResponse("default");
 	}
 

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/SDKDataConnectionsAuthorizationHandler.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/SDKDataConnectionsAuthorizationHandler.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.dataconnections;
+
+/**
+ * SDK-internal: meant for handling Data Connection Authorization.
+ */
+@FunctionalInterface
+interface SDKDataConnectionsAuthorizationHandler {
+	DataConnectionsAPIResult handleAuthorization(DataConnectionsHandlingContext context);
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/SDKDataConnectionsWebhooksHandler.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/SDKDataConnectionsWebhooksHandler.java
@@ -13,12 +13,10 @@
 
 package com.appdirect.sdk.appmarket.dataconnections;
 
-
 /**
  * SDK-internal: meant for handling Data Connection Webhooks
  */
 @FunctionalInterface
 interface SDKDataConnectionsWebhooksHandler {
-
 	DataConnectionsAPIResult handleWebhooks(DataConnectionsHandlingContext eventContext);
 }

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/SDKDataConnectionsWebhooksHandler.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/SDKDataConnectionsWebhooksHandler.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.dataconnections;
+
+
+/**
+ * SDK-internal: meant for handling Data Connection Webhooks
+ */
+@FunctionalInterface
+interface SDKDataConnectionsWebhooksHandler {
+
+	DataConnectionsAPIResult handleWebhooks(DataConnectionsHandlingContext eventContext);
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/dataconnections/WebhooksHandleWrapper.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/dataconnections/WebhooksHandleWrapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 AppDirect, Inc. and/or its affiliates
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdirect.sdk.appmarket.dataconnections;
+
+import com.appdirect.sdk.appmarket.AppmarketDataConnectionWebhooksHandler;
+
+/**
+ * SDK internal - Convenience class that wraps data connection webhooks handler
+ */
+class WebhooksHandleWrapper implements SDKDataConnectionsWebhooksHandler {
+
+	private final AppmarketDataConnectionWebhooksHandler dataConnectionHandler;
+
+	WebhooksHandleWrapper(AppmarketDataConnectionWebhooksHandler dataConnectionHandler) {
+		this.dataConnectionHandler = dataConnectionHandler;
+	}
+
+	@Override
+	public DataConnectionsAPIResult handleWebhooks(DataConnectionsHandlingContext context) {
+		return dataConnectionHandler.handleWebhooks(context);
+	}
+
+}

--- a/src/main/java/com/appdirect/sdk/appmarket/events/AppmarketCommunicationConfiguration.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/AppmarketCommunicationConfiguration.java
@@ -17,9 +17,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-//import com.appdirect.sdk.appmarket.dataconnections.DataConnectionsController;
-//import com.appdirect.sdk.appmarket.dataconnections.DataConnectionsAuthorizationDispatcher;
-//import com.appdirect.sdk.appmarket.dataconnections.DataConnectionsAuthorizationService;
 import com.appdirect.sdk.appmarket.DeveloperSpecificAppmarketCredentialsSupplier;
 import com.appdirect.sdk.appmarket.migration.AppmarketMigrationController;
 import com.appdirect.sdk.appmarket.migration.AppmarketMigrationService;
@@ -58,26 +55,6 @@ public class AppmarketCommunicationConfiguration {
 	public AppmarketEventController appmarketEventController(AppmarketEventService appmarketEventService, OAuthKeyExtractor oauthKeyExtractor) {
 		return new AppmarketEventController(appmarketEventService, oauthKeyExtractor);
 	}
-
-//	@Bean
-//	public DataConnectionsAuthorizationService dataConnectionsService(DataConnectionsAuthorizationDispatcher dispatcher) {
-//		return new DataConnectionsAuthorizationService(dispatcher);
-//	}
-//
-//	@Bean
-//	public DataConnectionsController dataConnectionsController(DataConnectionsAuthorizationService dataConnectionsService) {
-//		return new DataConnectionsController(dataConnectionsService);
-//	}
-
-//	@Bean
-//	public DataConnectionsAuthorizationService dataConnectionsService(DataConnectionsAuthorizationDispatcher dispatcher) {
-//		return new DataConnectionsAuthorizationService(dispatcher);
-//	}
-//
-//	@Bean
-//	public DataConnectionsController dataConnectionsController() {
-//		return new DataConnectionsController();
-//	}
 
 	@Bean
 	public AppmarketMigrationService appmarketMigrationService(CustomerAccountValidationHandler customerAccountValidationHandler, SubscriptionValidationHandler subscriptionValidationHandler) {

--- a/src/main/java/com/appdirect/sdk/appmarket/events/AppmarketCommunicationConfiguration.java
+++ b/src/main/java/com/appdirect/sdk/appmarket/events/AppmarketCommunicationConfiguration.java
@@ -17,6 +17,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+//import com.appdirect.sdk.appmarket.dataconnections.DataConnectionsController;
+//import com.appdirect.sdk.appmarket.dataconnections.DataConnectionsAuthorizationDispatcher;
+//import com.appdirect.sdk.appmarket.dataconnections.DataConnectionsAuthorizationService;
 import com.appdirect.sdk.appmarket.DeveloperSpecificAppmarketCredentialsSupplier;
 import com.appdirect.sdk.appmarket.migration.AppmarketMigrationController;
 import com.appdirect.sdk.appmarket.migration.AppmarketMigrationService;
@@ -55,6 +58,26 @@ public class AppmarketCommunicationConfiguration {
 	public AppmarketEventController appmarketEventController(AppmarketEventService appmarketEventService, OAuthKeyExtractor oauthKeyExtractor) {
 		return new AppmarketEventController(appmarketEventService, oauthKeyExtractor);
 	}
+
+//	@Bean
+//	public DataConnectionsAuthorizationService dataConnectionsService(DataConnectionsAuthorizationDispatcher dispatcher) {
+//		return new DataConnectionsAuthorizationService(dispatcher);
+//	}
+//
+//	@Bean
+//	public DataConnectionsController dataConnectionsController(DataConnectionsAuthorizationService dataConnectionsService) {
+//		return new DataConnectionsController(dataConnectionsService);
+//	}
+
+//	@Bean
+//	public DataConnectionsAuthorizationService dataConnectionsService(DataConnectionsAuthorizationDispatcher dispatcher) {
+//		return new DataConnectionsAuthorizationService(dispatcher);
+//	}
+//
+//	@Bean
+//	public DataConnectionsController dataConnectionsController() {
+//		return new DataConnectionsController();
+//	}
 
 	@Bean
 	public AppmarketMigrationService appmarketMigrationService(CustomerAccountValidationHandler customerAccountValidationHandler, SubscriptionValidationHandler subscriptionValidationHandler) {


### PR DESCRIPTION
JIRA ticket: CMS-17 (branch was mislabled CMS-18)

- [ ] Approved by a PI tech lead

NOTE: This PR is only pushing internally to @joeyfad's  Fork of service-integration-sdk. Once developers have reviewed  and approved, we may merge this into Adddirect/service-integration-sdk (Documentation MUST BE provided for this), OR it could live as it's own repo (i.e. keep the sdk's separate as some developers may not want the additional appwise and appinsights endpoints!).

The Purpose of this PR is to expose two additional endpoint placeholders which a developer can implement. The two endpoints are:
1. /authorization - placeholder for authenticating application users and connecting them to AppInsights and AppWise (and possibly future connectors) on demand.
2. /webhooks - provides an endpoint placeholder for developers to point their application webhooks. The implemented code (not in this PR!) will process webhook payloads:
a. for appwise, transform payloads into appwise event ingestions 
b. for appinsight analyze payloads and make appinsight dataset api calls

These endpoints placeholders are created in addition to the AppMarket event placeholders which are created by the code previous to this PR.

@jeremy-dimasuay and @hooriak, please forward this review to whom you think appropriate

@demjened optional reviewer



